### PR TITLE
Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,13 @@ setup(
     description='Excel file CLI Reader',
     long_description=open('README.rst').read(),
     license='Apache 2.0',
-    packages= [
+    packages=[
         'x_x',
     ],
     install_requires=[
         'xlrd',
         'click',
+        'six',
     ],
     entry_points='''
        [console_scripts]

--- a/x_x/asciitable.py
+++ b/x_x/asciitable.py
@@ -12,7 +12,10 @@ from six.moves import zip, zip_longest
 def write_bytes(s, out, encoding="utf-8"):
     """Provides 2 vs 3 compatibility for writing to ``out``"""
     if PY3:
-        out.write(bytes(s, encoding))
+        if isinstance(s, bytes):
+            out.write(s)
+        else:
+            out.write(bytes(s, encoding))
     else:
         out.write(s)
 
@@ -106,18 +109,14 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
     def heading_line(sizes):
         for size in sizes:
             write_bytes('+' + '-' * (size + 2), out)
-            # out.write(bytes('+' + '-' * (size + 2), "utf-8"))
         write_bytes('+\n', out)
-        # out.write(bytes('+\n', "utf-8"))
 
     def draw_headings(headings, sizes):
         heading_line(sizes)
         for idx, size in enumerate(sizes):
             fmt = '| %%-%is ' % size
             write_bytes((fmt % headings[idx]), out)
-            # out.write(bytes((fmt % headings[idx]), "utf-8"))
         write_bytes('|\n', out)
-        # out.write(bytes('|\n', "utf-8"))
         heading_line(sizes)
 
     cols, lines = termsize()
@@ -155,10 +154,8 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
                         value = value.encode('utf-8', 'replace')
                     except UnicodeDecodeError:
                         value = fmt % '?'
-                    out.write(value)
+                    write_bytes(value, out)
             write_bytes('|\n', out)
-            # out.write(bytes('|\n', "utf-8"))
         if not paginate:
             heading_line(sizes)
             write_bytes('|\n', out)
-            # out.write(bytes('\n', "utf-8"))

--- a/x_x/x_x.py
+++ b/x_x/x_x.py
@@ -1,11 +1,12 @@
 import itertools
 import string
 import os
+import subprocess
 
 import click
 import xlrd
 
-import asciitable
+from . import asciitable
 
 
 class XCursor(object):
@@ -18,7 +19,7 @@ class XCursor(object):
         if self.headingrow is not None:
             return [c.value for c in self.sheet.row(self.headingrow)]
         else:
-            u = string.uppercase
+            u = string.ascii_uppercase
             cols = len(self.sheet.row(0))
             return [''.join(r) for idx, r in
                     enumerate(itertools.chain(u, itertools.product(u, u)))
@@ -26,7 +27,7 @@ class XCursor(object):
 
     def __iter__(self):
         start = self.headingrow + 1 if self.headingrow is not None else 0
-        return ([c.value for c in self.sheet.row(n)] for n in xrange(start, self.sheet.nrows))
+        return ([c.value for c in self.sheet.row(n)] for n in range(start, self.sheet.nrows))
 
 
 @click.command()
@@ -39,6 +40,7 @@ def cli(filename, heading):
     """ things and stuff about stuff and things """
     workbook = xlrd.open_workbook(filename)
     sheet = workbook.sheet_by_index(0)
-    out = os.popen('less -FXRiS', 'w')
+    out = subprocess.Popen(
+        'less -FXRiS', shell=True, bufsize=0, stdin=subprocess.PIPE).stdin
+    # out = os.popen('less -FXRiS', 'w')
     asciitable.draw(XCursor(sheet, heading), out=out)
-


### PR DESCRIPTION
* Made several small changes suggested by `2to3`
* Added `six` as a requirement and  used a few compatibility helpers therein.
* Replaced the call to `os.popen` (which is deprecated) with `subprocess.Popen`.
* In `asciitable.py`, abstracted the output function (`write_bytes`) to be compatible with Python 3's changes in string behavior compared to Python 2.

I tested the final result in Python 2.7.9 and 3.4.3, and it seemed to work in both versions.

