### PR TITLE
Exit on BrokenPipeError (shallow fix)

### DIFF
--- a/x_x/asciitable.py
+++ b/x_x/asciitable.py
@@ -11,14 +11,16 @@ from six.moves import zip, zip_longest
 
 def write_bytes(s, out, encoding="utf-8"):
     """Provides 2 vs 3 compatibility for writing to ``out``"""
-    if PY3:
-        if isinstance(s, bytes):
-            out.write(s)
+    try:
+        if PY3:
+            if isinstance(s, bytes):
+                out.write(s)
+            else:
+                out.write(bytes(s, encoding))
         else:
-            out.write(bytes(s, encoding))
-    else:
-        out.write(s)
-
+            out.write(s)
+    except BrokenPipeError as bpe:
+        exit()
 
 def termsize():
     """Try to figure out the size of the current terminal.


### PR DESCRIPTION
Just wrap BrokenPipeError in try / except block and quit since the output pipe is probably closed.