### PR TITLE
Added CSV Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,24 +8,50 @@ x_x: The Dead Guy CLI
         :target: https://crate.io/packages/x_x/
 
 
-x_x is a Microsoft Excel file command line reader.  The purpose of this is to not break
-the workflow of people who live on the command line and need to access a
-spreadsheet generated using Microsoft Excel.
+x_x is a command line reader that displays either Excel files or CSVs in your terminal. The purpose of this is to not break the workflow of people who live on the command line and need to access a spreadsheet generated using Microsoft Excel.
 
 Install
 -------
 
-To install:
+The easy way:
 
 ::
 
-  $ pip install x_x
+    $ pip install x_x
 
+
+Or the hard way:
+
+::
+
+    $ git clone https://github.com/krockode/x_x.git && cd x_x && python setup.py install
 
 Usage
 -----
 
-Run using the `x_x` command:
+Installing this package gives you an ``x_x`` CLI executable.
+
+::
+
+    $ x_x --help
+    Usage: x_x [OPTIONS] FILENAME
+
+      Display Excel or CSV files directly on your terminal. The file type is
+      guessed from file extensions, but can be overridden with the --file-type
+      option.
+
+    Options:
+      -h, --heading INTEGER        Row number containing the headings.
+      -f, --file-type [csv|excel]  Force parsing of the file to the chosen format.
+      -d, --delimiter TEXT         Delimiter (only applicable to CSV files)
+                                   [default: ',']
+      -q, --quotechar TEXT         Quote character (only applicable to CSV files)
+                                   [default: '"']
+      -e, --encoding TEXT          Encoding [default: UTF-8]
+      --version                    Show the version and exit.
+      --help                       Show this message and exit.
+
+So, for example:
 
 ::
 
@@ -50,8 +76,38 @@ Or to specify a specific row as the header which will be visible on each page:
   | Harry Houdini | 52.0         |
   | Howard Hughes | 70.0         |
 
-For help use:
+Weird CSVs? No problem!
 
 ::
 
-  $ x_x --help
+    $ cat dead_guys.csv
+    person;age_at_death
+    Harrold Holt;59
+    Harry Houdini;52
+    Howard Hughes;70
+    |Not some guy, but just a string with ; in it|;0
+
+::
+
+    $ x_x -h 0 --delimiter=';' --quotechar='|' dead_guys.csv
+    +----------------------------------------------+--------------+
+    | person                                       | age_at_death |
+    +----------------------------------------------+--------------+
+    | Harrold Holt                                 | 59           |
+    | Harry Houdini                                | 52           |
+    | Howard Hughes                                | 70           |
+    | Not some guy, but just a string with ; in it | 0            |
+
+Does your CSV file not end in "csv"? Again, no problem:
+
+::
+
+    $ mv dead_guys.csv dead_guys.some_other_extension
+    $ x_x -h 0 --file-type=csv --delimiter=';' --quotechar='|' dead_guys.some_other_extension
+    +----------------------------------------------+--------------+
+    | person                                       | age_at_death |
+    +----------------------------------------------+--------------+
+    | Harrold Holt                                 | 59           |
+    | Harry Houdini                                | 52           |
+    | Howard Hughes                                | 70           |
+    | Not some guy, but just a string with ; in it | 0            |

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 from setuptools import setup
 from x_x import __version__
+from six import PY3
+
+requirements = ["xlrd", "click", "six"]
+
+if not PY3:
+    requirements.append("unicodecsv")
 
 setup(
     name='x_x',
@@ -14,11 +20,7 @@ setup(
     packages=[
         'x_x',
     ],
-    install_requires=[
-        'xlrd',
-        'click',
-        'six',
-    ],
+    install_requires=requirements,
     entry_points='''
        [console_scripts]
         x_x=x_x.x_x:cli

--- a/x_x/asciitable.py
+++ b/x_x/asciitable.py
@@ -7,19 +7,7 @@ import sys
 from six import string_types, PY3
 from six.moves import zip, zip_longest
 
-
-def write_bytes(s, out, encoding="utf-8"):
-    """Provides 2 vs 3 compatibility for writing to ``out``"""
-    try:
-        if PY3:
-            if isinstance(s, bytes):
-                out.write(s)
-            else:
-                out.write(bytes(s, encoding))
-        else:
-            out.write(s)
-    except IOError:
-        exit()
+from .compat import write_out
 
 
 def termsize():
@@ -110,15 +98,15 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
 
     def heading_line(sizes):
         for size in sizes:
-            write_bytes('+' + '-' * (size + 2), out)
-        write_bytes('+\n', out)
+            write_out('+' + '-' * (size + 2), out)
+        write_out('+\n', out)
 
     def draw_headings(headings, sizes):
         heading_line(sizes)
         for idx, size in enumerate(sizes):
             fmt = '| %%-%is ' % size
-            write_bytes((fmt % headings[idx]), out)
-        write_bytes('|\n', out)
+            write_out((fmt % headings[idx]), out)
+        write_out('|\n', out)
         heading_line(sizes)
 
     cols, lines = termsize()
@@ -156,8 +144,11 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
                         value = value.encode('utf-8', 'replace')
                     except UnicodeDecodeError:
                         value = fmt % '?'
-                    write_bytes(value, out)
-            write_bytes('|\n', out)
+                    write_out(value, out)
+            write_out('|\n', out)
         if not paginate:
             heading_line(sizes)
-            write_bytes('|\n', out)
+            write_out('|\n', out)
+
+    out.stdin.flush()
+    out.stdin.close()

--- a/x_x/compat.py
+++ b/x_x/compat.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+import codecs
+from six import PY3
+from contextlib import contextmanager
+from subprocess import Popen, PIPE
+
+if PY3:
+    import csv
+else:
+    import unicodecsv as csv
+
+
+def open_file(filename, encoding):
+    """For opening files for reading with a specified encoding (usually UTF-8)"""
+    if PY3:
+        return open(filename, encoding=encoding)
+    else:
+        return codecs.open(filename, "r", encoding)
+
+
+def write_out(s, out, encoding="utf-8"):
+    """Provides 2 vs 3 compatibility for writing to ``out``"""
+    try:
+        if PY3:
+            if isinstance(s, bytes):
+                out.stdin.write(s)
+            else:
+                out.stdin.write(bytes(s, encoding))
+        else:
+            out.stdin.write(s)
+    except IOError:
+        exit()
+
+
+@contextmanager
+def out_py2():
+    """Wrapping our call to ``less`` via ``Popen`` into a basic context manager for Python 2"""
+    out = Popen('less -FXRiS', shell=True, bufsize=0, stdin=PIPE)
+    yield out
+    out.wait()
+
+
+def out_proc():
+    """A context-enabled call to Popen"""
+    if PY3:
+        return Popen('less -FXRiS', shell=True, bufsize=0, stdin=PIPE)
+    else:
+        return out_py2()

--- a/x_x/cursor.py
+++ b/x_x/cursor.py
@@ -1,0 +1,43 @@
+import itertools
+import string
+
+
+class XCursor(object):
+
+    def __init__(self, sheet, headingrow=None):
+        self.headingrow = headingrow
+        self.sheet = sheet
+
+    def num_rows(self):
+        return self.sheet.nrows
+
+    def num_cols(self):
+        if self.headingrow is None:
+            return len(self.sheet_row(0))
+        else:
+            return len(self.sheet_row(self.headingrow))
+
+    def sheet_row(self, n):
+        return [c.value for c in self.sheet.row(n)]
+
+    def keys(self):
+        if self.headingrow is not None:
+            return self.sheet_row(self.headingrow)
+        else:
+            u = string.ascii_uppercase
+            return [''.join(r) for idx, r in
+                    enumerate(itertools.chain(u, itertools.product(u, u)))
+                    if idx < self.num_cols()]
+
+    def __iter__(self):
+        start = self.headingrow + 1 if self.headingrow is not None else 0
+        return (self.sheet_row(n) for n in range(start, self.num_rows()))
+
+
+class CSVCursor(XCursor):
+
+    def sheet_row(self, n):
+        return self.sheet[n]
+
+    def num_rows(self):
+        return len(self.sheet)

--- a/x_x/x_x.py
+++ b/x_x/x_x.py
@@ -1,32 +1,16 @@
+from __future__ import unicode_literals
+
 import string
 import itertools
-import subprocess
-
 import click
 import xlrd
+import os
 
 from . import asciitable, __version__
-
-
-class XCursor(object):
-
-    def __init__(self, sheet, headingrow=None):
-        self.headingrow = headingrow
-        self.sheet = sheet
-
-    def keys(self):
-        if self.headingrow is not None:
-            return [c.value for c in self.sheet.row(self.headingrow)]
-        else:
-            u = string.ascii_uppercase
-            cols = len(self.sheet.row(0))
-            return [''.join(r) for idx, r in
-                    enumerate(itertools.chain(u, itertools.product(u, u)))
-                    if idx < cols]
-
-    def __iter__(self):
-        start = self.headingrow + 1 if self.headingrow is not None else 0
-        return ([c.value for c in self.sheet.row(n)] for n in range(start, self.sheet.nrows))
+from .compat import open_file, csv, out_proc
+from .cursor import XCursor, CSVCursor
+from six import PY3
+from subprocess import Popen, PIPE
 
 
 @click.command()
@@ -34,13 +18,54 @@ class XCursor(object):
               '-h',
               type=int,
               help='Row number containing the headings.')
+@click.option("--file-type", "-f", type=click.Choice(["csv", "excel"]),
+              help="Force parsing of the file to the chosen format.")
+@click.option("--delimiter", "-d", type=str, default=",",
+              help="Delimiter (only applicable to CSV files) [default: ',']")
+@click.option("--quotechar", "-q", type=str, default='"',
+              help="Quote character (only applicable to CSV files) [default: '\"']")
+@click.option("--encoding", "-e", type=str, default="utf-8",
+              help="Encoding [default: UTF-8]")
 @click.version_option(version=__version__)
 @click.argument('filename')
-def cli(filename, heading):
-    """ things and stuff about stuff and things """
-    workbook = xlrd.open_workbook(filename)
-    sheet = workbook.sheet_by_index(0)
-    out = subprocess.Popen(
-        'less -FXRiS', shell=True, bufsize=0, stdin=subprocess.PIPE).stdin
-    # out = os.popen('less -FXRiS', 'w')
-    asciitable.draw(XCursor(sheet, heading), out=out)
+def cli(filename, heading, file_type, delimiter, quotechar, encoding):
+    """Display Excel or CSV files directly on your terminal.
+    The file type is guessed from file extensions, but can be overridden with the --file-type option.
+    """
+    if file_type is None:
+        if filename.endswith(".csv"):
+            file_type = "csv"
+        else:
+            file_type = "excel"
+
+    if file_type == "csv":
+
+        csv_rows = []
+
+        if not PY3:
+            delimiter = str(unicode(delimiter))
+            quotechar = str(unicode(quotechar))
+
+        with open_file(filename, encoding) as f:
+            reader = csv.reader(f, delimiter=delimiter, quotechar=quotechar)
+            for row in reader:
+                csv_rows.append(row)
+
+        cursor = CSVCursor(csv_rows, heading)
+
+    else:
+        # As per https://secure.simplistix.co.uk/svn/xlrd/trunk/xlrd/doc/xlrd.html?p=4966
+        # encodings in Excel are usually UTF-8. So, we only override the encoding
+        # if an encoding is specified by the user.
+        if encoding.lower() != "utf-8":
+            workbook = xlrd.open_workbook(filename, encoding_override=encoding)
+        else:
+            workbook = xlrd.open_workbook(filename)
+
+        sheet = workbook.sheet_by_index(0)
+
+        cursor = XCursor(sheet, heading)
+
+    with out_proc() as out:
+
+        asciitable.draw(cursor, out=out)


### PR DESCRIPTION
* Added the following CLI options:

    * `--file-type`: If enabled, must be one of `csv` or `excel`. This forces parsing of the file to the given file type. If not enabled, then the file is treated as a CSV if it ends in `.csv` and is treated as Excel otherwise.

    * `--delimiter` and `--quotechar`: CSV-only options that are passed directly into the CSV reader (defaults of `','` and `'"'`, respectively, of course).

    * `--encoding`: Allows the user to specify the file encoding (default of `utf-8`).

* Refactored the API for `XCursor` so that it could be easily extended to `CSVCursor`, and moved the cursor classes into a `cursor` module.

* Since `CSVCursor` has the same API as `XCursor` (and which is compatible with the previous (external) `XCursor` API), it can be passed into `asciitable.draw` with no problems.

* Changed `out` to a pipe (rather than just the pipe's `stdin`), disabled buffering on the `out` pipe and closed `out.stdin` at the end of `asciitable.draw` to help prevent errors when `less` is exited prematurely.

* Refactored most of the 2 vs 3 compatibility pieces into a `compat` module.

* Updated README, adding some relevant docs for these changes.